### PR TITLE
Sam/24x/fixups

### DIFF
--- a/src/btree/reql_specific.cc
+++ b/src/btree/reql_specific.cc
@@ -59,6 +59,7 @@ real_superblock_t::real_superblock_t(
 
 void real_superblock_t::release() {
     sb_buf_.reset_buf_lock();
+    write_semaphore_acq_.reset();
 }
 
 block_id_t real_superblock_t::get_root_block_id() {
@@ -391,7 +392,7 @@ void get_btree_superblock_and_txn_for_writing(
         sem_acq.acquisition_signal()->wait();
     }
 
-    get_btree_superblock(txn, access_t::write, got_superblock_out);
+    get_btree_superblock(txn, write_access_t::write, std::move(sem_acq), got_superblock_out);
 }
 
 void get_btree_superblock_and_txn_for_backfilling(

--- a/src/btree/reql_specific.hpp
+++ b/src/btree/reql_specific.hpp
@@ -8,7 +8,7 @@
 superblock; instead it manipulates the superblock using the abstract `superblock_t`. This
 file provides the concrete superblock implementation used for ReQL primary and sindex
 B-trees. It also provides functions for working with the secondary index block and the
-metainfo, which are unrelated to the B-tree but stored on the ReQL primary superblock. 
+metainfo, which are unrelated to the B-tree but stored on the ReQL primary superblock.
 
 `btree/secondary_operations.*` and `btree/reql_specific.*` are the only files in the
 `btree/` directory that know about ReQL-specific concepts such as metainfo and sindexes.
@@ -39,7 +39,7 @@ private:
     For writes it locks the write superblock acquisition semaphore until the
     sb_buf_ is released.
     Note that this is used to throttle writes compared to reads, but not required
-    for correctness. */    
+    for correctness. */
     new_semaphore_in_line_t write_semaphore_acq_;
 
     buf_lock_t sb_buf_;
@@ -181,7 +181,7 @@ void get_btree_superblock(
 /* Variant for writes that go through a superblock write semaphore */
 void get_btree_superblock(
         txn_t *txn,
-        access_t access,
+        write_access_t access,
         new_semaphore_in_line_t &&write_sem_acq,
         scoped_ptr_t<real_superblock_t> *got_superblock_out);
 

--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -211,18 +211,13 @@ void assertion_failed(char const * expr, char const * function, char const * fil
     T &operator=(T &&) = default
 
 
-/* Put these after functions to indicate what they throw. In release mode, they
+/* Put these after functions to indicate what they throw. In all modes, they
 turn into noops so that the compiler doesn't have to generate exception-checking
-code everywhere. If you need to add an exception specification for compatibility
-with e.g. a virtual method, don't use these, or your code won't compile in
-release mode. */
-#ifdef NDEBUG
+code everywhere.  Originally, these resolved to throw() and throw(__VA_ARGS__)
+in debug mode, but C++17 removed the language feature.  Consider these to be
+vestigial. */
 #define THROWS_NOTHING
 #define THROWS_ONLY(...)
-#else
-#define THROWS_NOTHING throw ()
-#define THROWS_ONLY(...) throw (__VA_ARGS__)
-#endif
 
 // This is a workaround for old versions of boost causing a compilation error
 #include <boost/version.hpp> // NOLINT(build/include_order)

--- a/src/unittest/extproc_test.cc
+++ b/src/unittest/extproc_test.cc
@@ -293,7 +293,7 @@ private:
     }
 };
 
-SPAWNER_TEST(ExtProc, CrashedJob) {
+SPAWNER_TEST(ExtProc, DISABLED_CrashedJob) {
     extproc_pool_t pool(1);
 
     // Crash the worker, then make sure it recovers and we can still run more jobs


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
This adds a few fixups to the v2.4.x branch.

- disables a test that, annoyingly, is failing all the time
- turns off debug-mode throws() checks, which are an obsolete C++ feature in C++17.

Most importantly:
- Re-introduces proper use of the superblock write semaphore!!!

This bug has been around since version 2.0.0, but it was not present in 1.16.

The consequences of this change is, if there is a big queue of writers lined up to write on a given table, readers are allowed to jump the line.